### PR TITLE
Misc small updates

### DIFF
--- a/src/authorized_client.ts
+++ b/src/authorized_client.ts
@@ -36,6 +36,15 @@ class AuthorizedClient {
   }
 
   /**
+   * Checks if the current client has ever authorized (possibly expired credentials).
+   *
+   * @returns {boolean}
+   */
+  public hasPreviouslyAuthorized(): boolean {
+    return CredentialsManager.isPossiblyValidFromClient(this.client);
+  }
+
+  /**
    * Authorizes the client to make request, and saves the credentials for a
    * later session.
    *

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -100,6 +100,10 @@ export class Component extends TypedReact.Component<Props, State> {
     var route = this.state.action.path;
 
     this.state.authorizedClient.get(route).then(function(response: any) {
+
+      // Add the corresponding action to the response for later use.
+      response.action = this.state.action;
+
       this.setState({
         response: response
       });

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -22,7 +22,7 @@ export interface Props {
 export interface State {
   authorizedClient?: AuthorizedClient;
   resource?: AsanaJson.Resource;
-  route?: string;
+  action?: AsanaJson.Action;
   response?: any;
 }
 
@@ -41,14 +41,14 @@ export class Component extends TypedReact.Component<Props, State> {
       Resources.resourceFromResourceName("Users");
 
     // If the initial route is valid, use it. Otherwise, use a valid one.
-    var valid_routes = Resources.routesFromResource(resource);
-    var route = (valid_routes.indexOf(this.props.initial_route) !== -1) ?
-      this.props.initial_route : valid_routes[0];
+    var action =
+      Resources.actionFromResourcePath(resource, this.props.initial_route) ||
+      resource.actions[0];
 
     return {
       authorizedClient: authorizedClient,
       resource: resource,
-      route: route
+      action: action
     };
   }
 
@@ -64,28 +64,29 @@ export class Component extends TypedReact.Component<Props, State> {
   }
 
   /**
-   * Updates the route state following an onChange event.
+   * Updates the resource state following an onChange event.
    */
   onChangeResourceState(event: React.FormEvent) {
     var resource = Resources.resourceFromResourceName(
       (<HTMLSelectElement>event.target).value);
 
-    // If the resource has changed, also update the route.
-    var route = (resource !== this.state.resource) ?
-      Resources.routesFromResource(resource)[0] : this.state.route;
+    // If the resource has changed, also update the action.
+    var action = (resource !== this.state.resource) ?
+      resource.actions[0] : this.state.action;
 
     this.setState({
       resource: resource,
-      route: route
+      action: action
     });
   }
 
   /**
-   * Updates the resource state following an onChange event.
+   * Updates the action state following an onChange event.
    */
-  onChangeRouteState(event: React.FormEvent) {
+  onChangeActionState(event: React.FormEvent) {
+    var route = (<HTMLSelectElement>event.target).value;
     this.setState({
-      route: (<HTMLSelectElement>event.target).value
+      action: Resources.actionFromResourcePath(this.state.resource, route)
     });
   }
 
@@ -96,7 +97,7 @@ export class Component extends TypedReact.Component<Props, State> {
   onSubmitRequest(event: React.FormEvent) {
     event.preventDefault();
 
-    var route = this.state.route;
+    var route = this.state.action.path;
 
     this.state.authorizedClient.get(route).then(function(response: any) {
       this.setState({
@@ -122,9 +123,9 @@ export class Component extends TypedReact.Component<Props, State> {
           }),
           RouteEntry.create({
             resource: this.state.resource,
-            route: this.state.route,
+            action: this.state.action,
             onFormSubmit: this.onSubmitRequest,
-            onRouteChange: this.onChangeRouteState
+            onActionChange: this.onChangeActionState
           }),
           JsonResponse.create({
             response: this.state.response

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -84,9 +84,9 @@ export class Component extends TypedReact.Component<Props, State> {
    * Updates the action state following an onChange event.
    */
   onChangeActionState(event: React.FormEvent) {
-    var route = (<HTMLSelectElement>event.target).value;
+    var action_name = (<HTMLSelectElement>event.target).value;
     this.setState({
-      action: Resources.actionFromResourcePath(this.state.resource, route)
+      action: Resources.actionFromName(this.state.resource, action_name)
     });
   }
 

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -111,7 +111,7 @@ export class Component extends TypedReact.Component<Props, State> {
   }
 
   render() {
-    if (!this.state.authorizedClient.isAuthorized()) {
+    if (!this.state.authorizedClient.hasPreviouslyAuthorized()) {
       return r.a({
         className: "authorize-link",
         href: "#",

--- a/src/components/json_response.ts
+++ b/src/components/json_response.ts
@@ -1,3 +1,5 @@
+/// <reference path="../asana_json.d.ts" />
+import AsanaJson = require("asana-json");
 import build = require("./build");
 import react = require("react");
 import TypedReact = require("typed-react");
@@ -12,18 +14,32 @@ export interface Props {
  * The JSON response code block.
  */
 export class Component extends TypedReact.Component<Props, {}> {
+  private _renderResponseHeaderInfo() {
+    if (this.props.response === undefined) {
+      return null;
+    }
+
+    var action: AsanaJson.Action = this.props.response.action;
+    return r.div({
+      className: "json-response-info"
+    }, action.method + " " + action.path);
+  }
+
   render() {
     var json_string = this.props.response === undefined ? null :
       JSON.stringify(this.props.response.data, undefined, 2);
 
-    return r.pre({
-      className: "json-response-block",
-      children: [
-        r.code({
-          className: "json"
-        }, json_string)
-      ]
-    });
+    return r.div({ },
+      this._renderResponseHeaderInfo(),
+      r.pre({
+        className: "json-response-block",
+        children: [
+          r.code({
+            className: "json"
+          }, json_string)
+        ]
+      })
+    );
   }
 }
 

--- a/src/components/route_entry.ts
+++ b/src/components/route_entry.ts
@@ -10,9 +10,9 @@ var r = react.DOM;
 
 export interface Props {
   resource: AsanaJson.Resource;
-  route: string;
+  action: AsanaJson.Action;
   onFormSubmit: (event?: React.FormEvent) => void;
-  onRouteChange: (event?: React.FormEvent) => void;
+  onActionChange: (event?: React.FormEvent) => void;
 }
 
 /**
@@ -23,8 +23,8 @@ export class Component extends TypedReact.Component<Props, {}> {
   private _renderSelectRoute() {
     return r.select({
       className: "select-route",
-      onChange: this.props.onRouteChange,
-      value: this.props.route,
+      onChange: this.props.onActionChange,
+      value: this.props.action.path,
       children: Resources.routesFromResource(this.props.resource).map(
           route => {
           return r.option({
@@ -35,20 +35,15 @@ export class Component extends TypedReact.Component<Props, {}> {
   }
 
   private _renderRouteInfo() {
-    var action = Resources.actionFromResourcePath(
-      this.props.resource,
-      this.props.route
-    );
-
     return r.div({ },
       r.div({ },
         r.strong({ }, "Route description: "),
-        action.comment
+        this.props.action.comment
       ),
       r.div({ },
         r.strong({ }, "Current route attributes: "),
-        action.params !== undefined ?
-          action.params.map(parameter => parameter.name).join() :
+        this.props.action.params !== undefined ?
+          this.props.action.params.map(parameter => parameter.name).join() :
           ""
       )
     );

--- a/src/components/route_entry.ts
+++ b/src/components/route_entry.ts
@@ -4,8 +4,6 @@ import build = require("./build");
 import react = require("react");
 import TypedReact = require("typed-react");
 
-import Resources = require("../resources");
-
 var r = react.DOM;
 
 export interface Props {
@@ -24,12 +22,12 @@ export class Component extends TypedReact.Component<Props, {}> {
     return r.select({
       className: "select-route",
       onChange: this.props.onActionChange,
-      value: this.props.action.path,
-      children: Resources.routesFromResource(this.props.resource).map(
-          route => {
+      value: this.props.action.name,
+      children: this.props.resource.actions.map(
+          action => {
           return r.option({
-            value: route
-          }, route);
+            value: action.name
+          }, action.path);
         })
     });
   }
@@ -45,6 +43,10 @@ export class Component extends TypedReact.Component<Props, {}> {
         this.props.action.params !== undefined ?
           this.props.action.params.map(parameter => parameter.name).join() :
           ""
+      ),
+      r.div({ },
+        r.strong({ }, "Route method: "),
+        this.props.action.method
       )
     );
 

--- a/src/credentials_manager.ts
+++ b/src/credentials_manager.ts
@@ -24,7 +24,7 @@ var EXPIRY_BUFFER_MS = 5 * 60 * 1000;
  */
 function isValid(credentials: Asana.auth.Credentials) {
   // If no credentials or expiry time, then mark as invalid.
-  if (credentials == null || credentials.expiry_timestamp == null) {
+  if (credentials === null || credentials.expiry_timestamp === null) {
     return false;
   }
 
@@ -40,6 +40,16 @@ function isValid(credentials: Asana.auth.Credentials) {
  */
 export function isValidFromClient(client: Asana.Client) {
   return isValid(getFromClient(client));
+}
+
+/**
+ * Returns true if the client has (possibly-expired) credentials.
+ *
+ * @param {Asana.Client} client
+ * @returns {boolean}
+ */
+export function isPossiblyValidFromClient(client: Asana.Client) {
+  return getFromClient(client) !== null;
 }
 
 /**

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -32,21 +32,20 @@ export function resourceNameFromResource(resource: AsanaJson.Resource): string {
 }
 
 /**
- * Returns the routes for a given resource.
- *
- * @param resource
- * @returns {string[]}
- */
-export function routesFromResource(resource: AsanaJson.Resource): string[] {
-  return resource.actions.map(action => { return action.path; });
-}
-
-/**
  * Return the action for a given resource and path string.
  *
  */
 export function actionFromResourcePath(resource: AsanaJson.Resource, path: string): AsanaJson.Action {
   return resource.actions.filter(
     action => { return path === action.path; }
+  )[0];
+}
+
+/**
+ * Returns the action by its resource and name.
+ */
+export function actionFromName(resource: AsanaJson.Resource, action_name: string): AsanaJson.Action {
+  return resource.actions.filter(
+    action => { return action_name === action.name; }
   )[0];
 }

--- a/test/authorized_client_spec.ts
+++ b/test/authorized_client_spec.ts
@@ -69,6 +69,17 @@ describe("AuthorizedClient", () => {
     });
   });
 
+  describe("#hasPreviouslyAuthorized", () => {
+    it("should pass through authorization check to credentials", () => {
+      var authorizedClient = new AuthorizedClient();
+      var stub = sand.stub(CredentialsManager, "isPossiblyValidFromClient");
+
+      authorizedClient.hasPreviouslyAuthorized();
+
+      sinon.assert.calledWith(stub, (<any>authorizedClient).client);
+    });
+  });
+
   describe("#authorizeIfExpired", () => {
     var authorizedClient: AuthorizedClient;
     var client: Asana.Client;

--- a/test/components/explorer_spec.ts
+++ b/test/components/explorer_spec.ts
@@ -145,19 +145,19 @@ describe("ExplorerComponent", () => {
     var selectRoute: React.HTMLComponent;
     var routeEntry: React.HTMLComponent;
 
-    var initial_route: string;
+    var initial_action: AsanaJson.Action;
     var initial_resource: AsanaJson.Resource;
 
     beforeEach(() => {
       isAuthorizedStub.returns(true);
 
       initial_resource = helpers.fetchResource(0);
-      initial_route = Resources.routesFromResource(initial_resource)[0];
+      initial_action = initial_resource.actions[0];
 
       root = testUtils.renderIntoDocument<Explorer.Component>(
         Explorer.create({
           initialAuthorizedClient: client,
-          initial_route: initial_route,
+          initial_route: initial_action.path,
           initial_resource_string:
             Resources.resourceNameFromResource(initial_resource)
         })
@@ -186,7 +186,7 @@ describe("ExplorerComponent", () => {
     it("should display the current route URL", () => {
       assert.include(
         (<HTMLInputElement>selectRoute.getDOMNode()).value,
-        initial_route
+        initial_action.name
       );
     });
 
@@ -198,7 +198,7 @@ describe("ExplorerComponent", () => {
       // Clicking the link should send request with the correct route.
       testUtils.Simulate.submit(routeEntry.getDOMNode());
       json_promise.then(function () {
-        sinon.assert.calledWith(getStub, initial_route);
+        sinon.assert.calledWith(getStub, initial_action.path);
 
         assert.equal(testUtils.findRenderedDOMComponentWithClass(
           root,
@@ -213,12 +213,12 @@ describe("ExplorerComponent", () => {
 
     it("should make the correct GET request after changing resource", (cb) => {
       var other_resource = helpers.fetchResource(1);
-      var other_route = Resources.routesFromResource(other_resource)[0];
+      var other_action = other_resource.actions[0];
 
       // Stub get request to return json.
       var json_promise = Promise.resolve({data: "{ a: 2 }"});
       var getStub = sand.stub(client, "get")
-        .withArgs(other_route).returns(json_promise);
+        .withArgs(other_action.path).returns(json_promise);
 
       // We change the resource, which in-turn will change the route.
       testUtils.Simulate.change(selectResource, {
@@ -228,7 +228,7 @@ describe("ExplorerComponent", () => {
       // Clicking the link should send request with the correct route.
       testUtils.Simulate.submit(routeEntry.getDOMNode());
       json_promise.then(function () {
-        sinon.assert.calledWith(getStub, other_route);
+        sinon.assert.calledWith(getStub, other_action.path);
 
         assert.equal(testUtils.findRenderedDOMComponentWithClass(
           root,
@@ -242,21 +242,21 @@ describe("ExplorerComponent", () => {
     });
 
     it("should make the correct GET request after changing route", (cb) => {
-      var other_route = Resources.routesFromResource(initial_resource)[1];
+      var other_action = initial_resource.actions[1];
 
       // Stub get request to return json.
       var json_promise = Promise.resolve({data: "{ a: 2 }"});
       var getStub = sand.stub(client, "get")
-        .withArgs(other_route).returns(json_promise);
+        .withArgs(other_action.path).returns(json_promise);
 
       testUtils.Simulate.change(selectRoute, {
-        target: { value: other_route }
+        target: { value: other_action.name }
       });
 
       // Clicking the link should send request with the correct route.
       testUtils.Simulate.submit(routeEntry.getDOMNode());
       json_promise.then(function () {
-        sinon.assert.calledWith(getStub, other_route);
+        sinon.assert.calledWith(getStub, other_action.path);
 
         assert.equal(testUtils.findRenderedDOMComponentWithClass(
           root,

--- a/test/components/explorer_spec.ts
+++ b/test/components/explorer_spec.ts
@@ -47,17 +47,17 @@ describe("ExplorerComponent", () => {
   describe("initial state", () => {
     it("should set initial routes if found in the resource", () => {
       var resource = helpers.fetchResource(0);
-      var valid_route = Resources.routesFromResource(resource)[1];
+      var valid_action = resource.actions[1];
       var explorer = testUtils.renderIntoDocument<Explorer.Component>(
         Explorer.create({
           initialAuthorizedClient: client,
           initial_resource_string:
             Resources.resourceNameFromResource(resource),
-          initial_route: valid_route
+          initial_route: valid_action.path
         })
       );
 
-      assert.equal(explorer.state.route, valid_route);
+      assert.equal(explorer.state.action, valid_action);
     });
 
     it("should ignore initial routes if not found in the resource", () => {
@@ -72,11 +72,8 @@ describe("ExplorerComponent", () => {
         })
       );
 
-      assert.notEqual(explorer.state.route, invalid_route);
-      assert.include(
-        Resources.routesFromResource(resource),
-        explorer.state.route
-      );
+      assert.notEqual(explorer.state.action.path, invalid_route);
+      assert.include(resource.actions, explorer.state.action);
     });
   });
 

--- a/test/components/explorer_spec.ts
+++ b/test/components/explorer_spec.ts
@@ -21,13 +21,13 @@ describe("ExplorerComponent", () => {
   var sand: SinonSandbox;
 
   var client: AuthorizedClient;
-  var isAuthorizedStub: SinonStub;
+  var hasPreviouslyAuthorizedStub: SinonStub;
 
   beforeEach(() => {
     sand = sinon.sandbox.create();
 
     client = new AuthorizedClient();
-    isAuthorizedStub = sand.stub(client, "isAuthorized");
+    hasPreviouslyAuthorizedStub = sand.stub(client, "hasPreviouslyAuthorized");
   });
 
   afterEach(() => {
@@ -41,7 +41,7 @@ describe("ExplorerComponent", () => {
       })
     );
 
-    sinon.assert.called(isAuthorizedStub);
+    sinon.assert.called(hasPreviouslyAuthorizedStub);
   });
 
   describe("initial state", () => {
@@ -83,7 +83,7 @@ describe("ExplorerComponent", () => {
     var children: NodeList;
 
     beforeEach(() => {
-      isAuthorizedStub.returns(false);
+      hasPreviouslyAuthorizedStub.returns(false);
 
       root = testUtils.renderIntoDocument<Explorer.Component>(
         Explorer.create({
@@ -111,7 +111,7 @@ describe("ExplorerComponent", () => {
       // Stub authorization to set the client to authorized.
       var promise: Promise<any>;
       var authorizeStub = sand.stub(client, "authorizeIfExpired", () => {
-          isAuthorizedStub.returns(true);
+          hasPreviouslyAuthorizedStub.returns(true);
           return promise = Promise.resolve();
         }
       );
@@ -149,7 +149,7 @@ describe("ExplorerComponent", () => {
     var initial_resource: AsanaJson.Resource;
 
     beforeEach(() => {
-      isAuthorizedStub.returns(true);
+      hasPreviouslyAuthorizedStub.returns(true);
 
       initial_resource = helpers.fetchResource(0);
       initial_action = initial_resource.actions[0];

--- a/test/components/json_response_spec.ts
+++ b/test/components/json_response_spec.ts
@@ -7,6 +7,7 @@ import react = require("react/addons");
 import sinon = require("sinon");
 
 import JsonResponse = require("../../src/components/json_response");
+import helpers = require("../helpers");
 
 var assert = chai.assert;
 var testUtils = react.addons.TestUtils;
@@ -15,8 +16,7 @@ describe("JsonResponseComponent", () => {
   var sand: SinonSandbox;
 
   var root: JsonResponse.Component;
-  var node: Node;
-  var children: NodeList;
+  var responseBlock: React.HTMLComponent;
   var stringifySpy: SinonSpy;
 
   beforeEach(() => {
@@ -27,9 +27,10 @@ describe("JsonResponseComponent", () => {
     root = testUtils.renderIntoDocument<JsonResponse.Component>(
       JsonResponse.create({ response: undefined })
     );
-    node = root.getDOMNode();
-    children = node.childNodes;
-
+    responseBlock = testUtils.findRenderedDOMComponentWithClass(
+      root,
+      "json-response-block"
+    );
   });
 
   afterEach(() => {
@@ -41,27 +42,38 @@ describe("JsonResponseComponent", () => {
     sinon.assert.notCalled(stringifySpy);
 
     // Verify the DOM is as expected.
+    var node = responseBlock.getDOMNode();
     assert.equal(node.nodeName, "PRE");
-    assert.equal(children.length, 1);
-    assert.equal(children[0].nodeName, "CODE");
-    assert.equal(children[0].textContent, "");
+    assert.equal(node.childNodes.length, 1);
+    assert.equal(node.childNodes[0].nodeName, "CODE");
+    assert.equal(node.childNodes[0].textContent, "");
   });
 
   it("should show non-empty json response after updating props", () => {
+    var action = helpers.fetchResource(0).actions[0];
     // Update the state to have a non-empty response.
     var json = "{ test: { again: 2 } }";
     testUtils.findRenderedComponentWithType(
       root,
       JsonResponse.create
-    ).setProps({ response: { data: json } });
+    ).setProps({ response: { data: json, action: action } });
 
     // We should stringify a non-empty string.
     sinon.assert.calledWith(stringifySpy, json);
 
-    // Verify the DOM updated as expected.
+    // Verify the DOM for the json response block.
+    var node = responseBlock.getDOMNode();
     assert.equal(node.nodeName, "PRE");
-    assert.equal(children.length, 1);
-    assert.equal(children[0].nodeName, "CODE");
-    assert.equal(children[0].textContent, "\"" + json + "\"");
+    assert.equal(node.childNodes.length, 1);
+    assert.equal(node.childNodes[0].nodeName, "CODE");
+    assert.equal(node.childNodes[0].textContent, "\"" + json + "\"");
+
+    // Verify the DOM for the response header info.
+    var responseInfo = testUtils.findRenderedDOMComponentWithClass(
+      root,
+      "json-response-info"
+    );
+    assert.include(responseInfo.getDOMNode().textContent, action.method);
+    assert.include(responseInfo.getDOMNode().textContent, action.path);
   });
 });

--- a/test/components/route_entry_spec.ts
+++ b/test/components/route_entry_spec.ts
@@ -8,7 +8,6 @@ import chai = require("chai");
 import react = require("react/addons");
 import sinon = require("sinon");
 
-import Resources = require("../../src/resources");
 import RouteEntry = require("../../src/components/route_entry");
 import helpers = require("../helpers");
 
@@ -57,20 +56,18 @@ describe("RouteEntryComponent", () => {
   it("should select the current route", () => {
     assert.include(
       (<HTMLInputElement>selectRoute.getDOMNode()).value,
-      initial_action.path
+      initial_action.name
     );
   });
 
   it("should contain dropdown with other routes", () => {
     var children = selectRoute.getDOMNode().childNodes;
-    var routes = Resources.routesFromResource(initial_resource);
 
-    assert.equal(children.length, routes.length);
-    routes.forEach((route, idx) => {
-      assert.equal(
-        (<HTMLOptionElement>children.item(idx)).value,
-        route
-      );
+    assert.equal(children.length, initial_resource.actions.length);
+    initial_resource.actions.forEach((action, idx) => {
+      var child_item = (<HTMLOptionElement>children.item(idx));
+      assert.equal(child_item.value, action.name);
+      assert.equal(child_item.text, action.path);
     });
   });
 
@@ -80,10 +77,10 @@ describe("RouteEntryComponent", () => {
   });
 
   it("should trigger onRouteChange property on route change", () => {
-    var other_route = Resources.routesFromResource(initial_resource)[1];
+    var other_action = initial_resource.actions[1];
 
     testUtils.Simulate.change(selectRoute, {
-      target: { value: other_route }
+      target: { value: other_action.name }
     });
     sinon.assert.called(onActionChangeStub);
   });

--- a/test/components/route_entry_spec.ts
+++ b/test/components/route_entry_spec.ts
@@ -18,11 +18,11 @@ var testUtils = react.addons.TestUtils;
 describe("RouteEntryComponent", () => {
   var sand: SinonSandbox;
 
-  var initial_route: string;
+  var initial_action: AsanaJson.Action;
   var initial_resource: AsanaJson.Resource;
 
   var onFormSubmitStub: SinonStub;
-  var onRouteChangeStub: SinonStub;
+  var onActionChangeStub: SinonStub;
 
   var root: RouteEntry.Component;
   var selectRoute: React.HTMLComponent;
@@ -31,17 +31,17 @@ describe("RouteEntryComponent", () => {
     sand = sinon.sandbox.create();
 
     initial_resource = helpers.fetchResource(2);
-    initial_route = Resources.routesFromResource(initial_resource)[0];
+    initial_action = initial_resource.actions[0];
 
     onFormSubmitStub = sand.stub();
-    onRouteChangeStub = sand.stub();
+    onActionChangeStub = sand.stub();
 
     root = testUtils.renderIntoDocument<RouteEntry.Component>(
       RouteEntry.create({
-        route: initial_route,
+        action: initial_action,
         resource: initial_resource,
         onFormSubmit: onFormSubmitStub,
-        onRouteChange: onRouteChangeStub
+        onActionChange: onActionChangeStub
       })
     );
     selectRoute = testUtils.findRenderedDOMComponentWithClass(
@@ -57,7 +57,7 @@ describe("RouteEntryComponent", () => {
   it("should select the current route", () => {
     assert.include(
       (<HTMLInputElement>selectRoute.getDOMNode()).value,
-      initial_route
+      initial_action.path
     );
   });
 
@@ -85,6 +85,6 @@ describe("RouteEntryComponent", () => {
     testUtils.Simulate.change(selectRoute, {
       target: { value: other_route }
     });
-    sinon.assert.called(onRouteChangeStub);
+    sinon.assert.called(onActionChangeStub);
   });
 });

--- a/test/credentials_manager_spec.ts
+++ b/test/credentials_manager_spec.ts
@@ -55,6 +55,37 @@ describe("CredentialsManager", () => {
     });
   });
 
+  describe("#isPossiblyValidFromClient", () => {
+    it("should fail with null credentials", () => {
+      var client = helpers.createOauthClient(null);
+      assert.isFalse(CredentialsManager.isPossiblyValidFromClient(client));
+    });
+
+    it("should pass with expired credentials", () => {
+      var client = helpers.createOauthClient(
+        helpers.createCredentials(Date.now())
+      );
+      sand.clock.tick(500);
+      assert.isTrue(CredentialsManager.isPossiblyValidFromClient(client));
+    });
+
+    it("should pass with soon-to-expire credentials", () => {
+      var client = helpers.createOauthClient(
+        helpers.createCredentials(Date.now() + 2 * MINUTE_IN_MS)
+      );
+
+      assert.isTrue(CredentialsManager.isPossiblyValidFromClient(client));
+    });
+
+    it("should succeed with long-to-expire credentials", () => {
+      var client = helpers.createOauthClient(
+        helpers.createCredentials(Date.now() + 20 * MINUTE_IN_MS)
+      );
+
+      assert.isTrue(CredentialsManager.isPossiblyValidFromClient(client));
+    });
+  });
+
   describe("localStorage", () => {
     var oldStorage: Storage;
     var localStorage: Storage;


### PR DESCRIPTION
- Keep track of action in state, rather than simply the route string
- Use action name is selector, not the route string. This caused a bug since multiple routes have the same path.
- Display the current method and route above the JSON blob (e.g. `GET /users/me`)