### PR TITLE
Improve authorization experience

### DIFF
--- a/src/asana.d.ts
+++ b/src/asana.d.ts
@@ -15,6 +15,7 @@ declare module "asana" {
   export class Dispatcher {
     get(path: string, query: any, dispatchOptions: any): Promise<any>;
     authenticator: auth.Authenticator;
+    handleUnauthorized(): Promise<any>;
   }
 
   export module auth {


### PR DESCRIPTION
- Allow an unauthorized user to use the api tester in a view-only state
- Instead of allowing popups (that could potentially be blocked), give
  the user a helpful message and link to authorize.
- If we think a user's state is expired (on page-load), then treat them
  as having expired credentials. This reduces friction since the user
  won't need to send a request and have it fail.
- If a user's state becomes expired (after page-load), then show them
  their error message and give them a link to re-authorize.