### PR TITLE
Replace %d in route with parameter name

### DIFF
--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -4,7 +4,6 @@ import Asana = require("asana");
 import Promise = require("bluebird");
 import React = require("react/addons");
 import url = require("url");
-import util = require("util");
 import _ = require("lodash");
 
 import constants = require("../constants");
@@ -120,15 +119,17 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
 
   /**
    * Uses the state to return the URL for the current request.
+   * Assumes we have at-most one required parameter to put in the URL.
+   *
    * @returns {string}
    */
   requestUrl = (): string => {
-    // Assumes we have at-most one required parameter to put in the URL.
-    var required_params = this.state.params.required_params;
+    var param_value: number;
+    if (!_.isEmpty(this.state.params.required_params)) {
+      param_value = _.values(this.state.params.required_params)[0];
+    }
 
-    return !_.isEmpty(required_params) ?
-      util.format(this.state.action.path, _.values(required_params)[0]) :
-      this.state.action.path;
+    return ResourcesHelpers.pathForAction(this.state.action, param_value);
   };
 
   /**

--- a/src/components/route_entry.ts
+++ b/src/components/route_entry.ts
@@ -1,6 +1,8 @@
 /// <reference path="../resources/interfaces.ts" />
 import React = require("react");
 
+import ResourcesHelpers = require("../resources/helpers");
+
 var r = React.DOM;
 
 /**
@@ -18,7 +20,7 @@ class RouteEntry extends React.Component<RouteEntry.Props, {}> {
           action => {
           return r.option({
             value: action.name
-          }, action.path);
+          }, ResourcesHelpers.pathForAction(action));
         })
     });
   };

--- a/test/components/route_entry_spec.ts
+++ b/test/components/route_entry_spec.ts
@@ -2,6 +2,7 @@
 import chai = require("chai");
 import React = require("react/addons");
 import sinon = require("sinon");
+import _ = require("lodash");
 
 import Resources = require("../../src/resources/resources");
 import RouteEntry = require("../../src/components/route_entry");
@@ -88,8 +89,14 @@ describe("RouteEntryComponent", () => {
       assert.equal(children.length, initial_resource.actions.length);
       initial_resource.actions.forEach((action, idx) => {
         var child_item = (<HTMLOptionElement>children.item(idx));
+
+        // Replace any placeholders with their required param name.
+        var required_param = _.find(action.params, "required");
+        var action_path = required_param !== undefined ?
+          action.path.replace("%d", ":" + required_param.name) : action.path;
+
         assert.equal(child_item.value, action.name);
-        assert.equal(child_item.text, action.path);
+        assert.equal(child_item.text, action_path);
       });
     });
 


### PR DESCRIPTION
In the route dropdowns, as well as the URL preview.

Submit is disabled when required parameters are missing, so it's okay
to have the placeholder text in the URL.