### PR TITLE
Add extra parameter entry improve error handling

### DIFF
--- a/src/components/parameter_entry.ts
+++ b/src/components/parameter_entry.ts
@@ -48,6 +48,18 @@ class ParameterEntry extends React.Component<ParameterEntry.Props, {}> {
     }
   };
 
+  private _renderExtraParameterInput = () => {
+    return r.span({ key: "extra" },
+      r.input({
+        placeholder: "Extra parameters",
+        type: "text",
+        id: "extra_parameter_input",
+        className: "parameter-input extra-param",
+        onChange: this.props.onParameterChange(null)
+      }, "Extra parameters")
+    );
+  };
+
   render() {
     return r.div({
         className: "parameter-entry",
@@ -56,7 +68,9 @@ class ParameterEntry extends React.Component<ParameterEntry.Props, {}> {
           r.span({
             className: "parameter-inputs"
           }, this.props.parameters === undefined ? "" :
-            this.props.parameters.map(this._renderParameterInput))
+            this.props.parameters.map(this._renderParameterInput)),
+          r.br(),
+          this._renderExtraParameterInput()
         ]
       }
     );

--- a/test/components/parameter_entry_spec.ts
+++ b/test/components/parameter_entry_spec.ts
@@ -49,13 +49,23 @@ describe("ParameterEntryComponent", () => {
   it("should contain an input for each parameter", () => {
     var parameter_names = _.pluck(parameters, "name");
 
-    assert.equal(inputs.length, parameters.length);
-    inputs.forEach(input => {
+    // Filter out the extra-param for this test.
+    var parameter_inputs = _.filter(
+      inputs, input => !_.contains(input.props.className, "extra-param"));
+
+    parameter_inputs.forEach(input => {
       assert.include(
         parameter_names,
         input.props.children
       );
     });
+  });
+
+  it("should contain an input for extra params", () => {
+    var extra_param_input = _.find(
+      inputs, input => _.contains(input.props.className, "extra-param"));
+
+    assert.equal(extra_param_input.props.children, "Extra parameters");
   });
 
   it("should trigger onChange parameter when text is entered", () => {


### PR DESCRIPTION
- Add new parameter field for extra parameters, which takes in valid
  JSON to allow the user to input any parameter.
- Change `canSubmitRequest` logic to use an enum for different state
  conditions. Different types of invalid state are represented, so
  we can display a helpful error message to the user when submit is
  disabled. For example, invalid JSON in the extra parameters displays
  a message with an example of valid JSON.
- Update tests accordingly.