### PR TITLE
Use key:value input pair for extra parameters

### DIFF
--- a/src/components/extra_parameter_entry.ts
+++ b/src/components/extra_parameter_entry.ts
@@ -1,0 +1,125 @@
+/// <reference path="../resources/interfaces.ts" />
+import React = require("react/addons");
+import _ = require("lodash");
+
+var r = React.DOM;
+var update = React.addons.update;
+
+// TODO: Update tests.
+
+/**
+ * The extra parameter input area
+ */
+class ExtraParameterEntry extends React.Component<ExtraParameterEntry.Props, ExtraParameterEntry.State> {
+  static create = React.createFactory(ExtraParameterEntry);
+
+  constructor(props: ExtraParameterEntry.Props, context: any) {
+    super(props, context);
+    this.state = {
+      extra_params: []
+    };
+  }
+
+  private _setStateAndPropagate(new_state: ExtraParameterEntry.State) {
+    this.setState(new_state);
+
+    // Pass new list of extra params to prop function, so we can propagate
+    // changes in the parent component.
+    this.props.syncExtraParameters(new_state.extra_params);
+  }
+
+  private _renderAddNewExtraParameterLink = () => {
+    return r.a({
+      className: "add-extra-param",
+      href: "#",
+      onClick: () => {
+        this.setState(update(this.state, <any>{
+          extra_params: {
+            $push: [<ExtraParameterEntry.ExtraParameter>{
+              key: "",
+              value: ""
+            }]
+          }
+        }));
+      }
+    }, "Add new parameter!");
+  };
+
+  private _renderExtraParameterInput = (extra_param: ExtraParameterEntry.ExtraParameter, idx: number) => {
+    var id_prefix = "extra_param_" + idx;
+
+    return r.div({ key: id_prefix },
+      r.input({
+        placeholder: "Key",
+        type: "text",
+        id: id_prefix + "_key",
+        className: "parameter-input extra-param",
+        value: this.state.extra_params[idx].key,
+        onChange: (event: React.FormEvent) => {
+          this._setStateAndPropagate(update(this.state, <any>{
+            extra_params: _.object(
+              [idx.toString()],
+              [{ key: { $set: (<any>event.target).value } }]
+            )
+          }));
+        }
+      }),
+      ":",
+      r.input({
+        placeholder: "Value",
+        type: "text",
+        id: id_prefix + "_value",
+        className: "parameter-input extra-param",
+        value: this.state.extra_params[idx].value,
+        onChange: (event: React.FormEvent) => {
+          this._setStateAndPropagate(update(this.state, <any>{
+            extra_params: _.object(
+              [idx.toString()],
+              [{ value: { $set: (<any>event.target).value } }]
+            )
+          }));
+        }
+      }),
+      r.span({
+        className: "delete-extra-param",
+        onClick: () => {
+          this._setStateAndPropagate(update(this.state, <any> {
+            extra_params: {
+              $splice: [[ idx, 1 ]]
+            }
+          }));
+        }
+      }, "X")
+    );
+  };
+
+  render() {
+    return r.div({
+        className: "parameter-entry",
+        children: [
+          this.props.text,
+          this.state.extra_params.map(this._renderExtraParameterInput),
+          this._renderAddNewExtraParameterLink()
+        ]
+      }
+    );
+  }
+}
+
+module ExtraParameterEntry {
+  export interface ExtraParameter {
+    key: string;
+    value: string;
+  }
+
+  export interface Props {
+    text: string;
+    syncExtraParameters: (parameters: ExtraParameter[]) => void;
+  }
+
+  export interface State {
+    extra_params: ExtraParameter[];
+  }
+}
+
+export = ExtraParameterEntry;

--- a/src/components/extra_parameter_entry.ts
+++ b/src/components/extra_parameter_entry.ts
@@ -5,8 +5,6 @@ import _ = require("lodash");
 var r = React.DOM;
 var update = React.addons.update;
 
-// TODO: Update tests.
-
 /**
  * The extra parameter input area
  */
@@ -48,49 +46,53 @@ class ExtraParameterEntry extends React.Component<ExtraParameterEntry.Props, Ext
   private _renderExtraParameterInput = (extra_param: ExtraParameterEntry.ExtraParameter, idx: number) => {
     var id_prefix = "extra_param_" + idx;
 
-    return r.div({ key: id_prefix },
-      r.input({
-        placeholder: "Key",
-        type: "text",
-        id: id_prefix + "_key",
-        className: "parameter-input extra-param",
-        value: this.state.extra_params[idx].key,
-        onChange: (event: React.FormEvent) => {
-          this._setStateAndPropagate(update(this.state, <any>{
-            extra_params: _.object(
-              [idx.toString()],
-              [{ key: { $set: (<any>event.target).value } }]
-            )
-          }));
-        }
-      }),
-      ":",
-      r.input({
-        placeholder: "Value",
-        type: "text",
-        id: id_prefix + "_value",
-        className: "parameter-input extra-param",
-        value: this.state.extra_params[idx].value,
-        onChange: (event: React.FormEvent) => {
-          this._setStateAndPropagate(update(this.state, <any>{
-            extra_params: _.object(
-              [idx.toString()],
-              [{ value: { $set: (<any>event.target).value } }]
-            )
-          }));
-        }
-      }),
-      r.span({
-        className: "delete-extra-param",
-        onClick: () => {
-          this._setStateAndPropagate(update(this.state, <any> {
-            extra_params: {
-              $splice: [[ idx, 1 ]]
-            }
-          }));
-        }
-      }, "X")
-    );
+    return r.div({
+      key: id_prefix,
+      className: "extra-param",
+      children: [
+        r.input({
+          placeholder: "Key",
+          type: "text",
+          id: id_prefix + "_key",
+          className: "parameter-input extra-param-key",
+          value: this.state.extra_params[idx].key,
+          onChange: (event: React.FormEvent) => {
+            this._setStateAndPropagate(update(this.state, <any>{
+              extra_params: _.object(
+                [idx.toString()],
+                [{ key: { $set: (<any>event.target).value } }]
+              )
+            }));
+          }
+        }),
+        ":",
+        r.input({
+          placeholder: "Value",
+          type: "text",
+          id: id_prefix + "_value",
+          className: "parameter-input extra-param-value",
+          value: this.state.extra_params[idx].value,
+          onChange: (event: React.FormEvent) => {
+            this._setStateAndPropagate(update(this.state, <any>{
+              extra_params: _.object(
+                [idx.toString()],
+                [{ value: { $set: (<any>event.target).value } }]
+              )
+            }));
+          }
+        }),
+        r.span({
+          className: "delete-extra-param",
+          onClick: () => {
+            this._setStateAndPropagate(update(this.state, <any> {
+              extra_params: {
+                $splice: [[ idx, 1 ]]
+              }
+            }));
+          }
+        }, "X")
+      ]
+    });
   };
 
   render() {

--- a/src/components/parameter_entry.ts
+++ b/src/components/parameter_entry.ts
@@ -48,18 +48,6 @@ class ParameterEntry extends React.Component<ParameterEntry.Props, {}> {
     }
   };
 
-  private _renderExtraParameterInput = () => {
-    return r.span({ key: "extra" },
-      r.input({
-        placeholder: "Extra parameters",
-        type: "text",
-        id: "extra_parameter_input",
-        className: "parameter-input extra-param",
-        onChange: this.props.onParameterChange(null)
-      }, "Extra parameters")
-    );
-  };
-
   render() {
     return r.div({
         className: "parameter-entry",
@@ -68,9 +56,7 @@ class ParameterEntry extends React.Component<ParameterEntry.Props, {}> {
           r.span({
             className: "parameter-inputs"
           }, this.props.parameters === undefined ? "" :
-            this.props.parameters.map(this._renderParameterInput)),
-          r.br(),
-          this._renderExtraParameterInput()
+            this.props.parameters.map(this._renderParameterInput))
         ]
       }
     );

--- a/test/components/explorer_spec.ts
+++ b/test/components/explorer_spec.ts
@@ -668,50 +668,7 @@ describe("ExplorerComponent", () => {
             root.state.params.optional_params.other_example = "other data";
           });
 
-          it("should set extra parameters after inputting valid JSON", () => {
-            testUtils.Simulate.change(extraParam, {
-              target: {
-                className: extraParam.props.className,
-                value: "{ \"a\": 123, \"b\": \"abc\" }"
-              }
-            });
-
-            assert.deepEqual(
-              root.state.params.extra_params,
-              { a: 123, b: "abc" }
-            );
-
-            // Other parameters should be unchanged.
-            assert.deepEqual(
-              root.state.params.required_params,
-              { example: "data here" }
-            );
-            assert.deepEqual(
-              root.state.params.optional_params,
-              { other_example: "other data" }
-            );
-          });
-
-          it("should unset extra parameters after inputting invalid JSON", () => {
-            testUtils.Simulate.change(extraParam, {
-              target: {
-                className: extraParam.props.className,
-                value: "invalid_json"
-              }
-            });
-
-            assert.isNull(root.state.params.extra_params);
-
-            // Other parameters should be unchanged.
-            assert.deepEqual(
-              root.state.params.required_params,
-              { example: "data here" }
-            );
-            assert.deepEqual(
-              root.state.params.optional_params,
-              { other_example: "other data" }
-            );
-          });
+          // TODO: Add tests for extra params.
         });
       });
 
@@ -994,54 +951,6 @@ describe("ExplorerComponent", () => {
         assert.equal(
           root.userStateStatus(),
           Explorer.UserStateStatus.ErrorUnsupportedMethodType);
-      });
-
-      it("should be disabled with invalid extra params", () => {
-        // First make in a valid state.
-        testUtils.Simulate.change(selectResource, {
-          target: { value: "Users" }
-        });
-        assert.isFalse(submitRequest.props.disabled);
-
-        // Now set the extra param to an invalid state.
-        var extraParam = testUtils.findRenderedDOMComponentWithClass(
-          root, "extra-param");
-
-        testUtils.Simulate.change(extraParam, {
-          target: {
-            className: extraParam.props.className,
-            value: "invalid json"
-          }
-        });
-
-        assert.isTrue(submitRequest.props.disabled);
-        assert.equal(
-          root.userStateStatus(),
-          Explorer.UserStateStatus.ErrorInvalidExtraParams);
-      });
-
-      it("should be enabled with extra params using valid JSON", () => {
-        // First make in a valid state.
-        testUtils.Simulate.change(selectResource, {
-          target: { value: "Users" }
-        });
-        assert.isFalse(submitRequest.props.disabled);
-
-        // Now set the extra param to a valid state.
-        var extraParam = testUtils.findRenderedDOMComponentWithClass(
-          root, "extra-param");
-
-        testUtils.Simulate.change(extraParam, {
-          target: {
-            className: extraParam.props.className,
-            value: "{ \"this\": \"is valid json\" }"
-          }
-        });
-
-        assert.isFalse(submitRequest.props.disabled);
-        assert.equal(
-          root.userStateStatus(),
-          Explorer.UserStateStatus.Okay);
       });
 
       it("should throw when the user submits on disabled state", () => {

--- a/test/components/extra_parameter_entry_spec.ts
+++ b/test/components/extra_parameter_entry_spec.ts
@@ -1,0 +1,162 @@
+import chai = require("chai");
+import React = require("react/addons");
+import sinon = require("sinon");
+import _ = require("lodash");
+
+import ExtraParameterEntry = require("../../src/components/extra_parameter_entry");
+
+var assert = chai.assert;
+var testUtils = React.addons.TestUtils;
+
+describe("ExtraParameterEntryComponent", () => {
+  var sand: SinonSandbox;
+
+  var syncExtraParametersStub: SinonStub;
+
+  var root: ExtraParameterEntry;
+  var addExtraParam: React.HTMLComponent;
+
+  beforeEach(() => {
+    sand = sinon.sandbox.create();
+
+    syncExtraParametersStub = sand.stub();
+
+    root = testUtils.renderIntoDocument<ExtraParameterEntry>(
+      ExtraParameterEntry.create({
+        text: "this is a test",
+        syncExtraParameters: syncExtraParametersStub
+      })
+    );
+    addExtraParam = testUtils.findRenderedDOMComponentWithClass(
+      root,
+      "add-extra-param"
+    );
+  });
+
+  afterEach(() => {
+    sand.restore();
+  });
+
+  function _assertNumberOfExtraParams(n: number) {
+    assert.lengthOf(root.state.extra_params, n);
+
+    assert.lengthOf(
+      testUtils.scryRenderedDOMComponentsWithClass(root, "extra-param-key"),
+      n
+    );
+    assert.lengthOf(
+      testUtils.scryRenderedDOMComponentsWithClass(root, "extra-param-value"),
+      n
+    );
+    assert.lengthOf(
+      testUtils.scryRenderedDOMComponentsWithClass(root, "extra-param"),
+      n
+    );
+  }
+
+  it("should initialize with no extra parameter fields", () => {
+    _assertNumberOfExtraParams(0);
+  });
+
+  it("should add a parameter field after clicking link", () => {
+    testUtils.Simulate.click(addExtraParam);
+    _assertNumberOfExtraParams(1);
+
+    testUtils.Simulate.click(addExtraParam);
+    _assertNumberOfExtraParams(2);
+  });
+
+  it("should update state and trigger sync when text is entered", () => {
+    // First add a few parameters so we can enter text in those fields.
+    testUtils.Simulate.click(addExtraParam);
+    testUtils.Simulate.click(addExtraParam);
+    testUtils.Simulate.click(addExtraParam);
+    var extraParams = testUtils.scryRenderedDOMComponentsWithClass(
+      root,
+      "extra-param"
+    );
+
+    // For each extra parameter, we'll input data and verify it updated.
+    extraParams.forEach(extraParam => {
+      var keyInput = testUtils.findRenderedDOMComponentWithClass(
+        extraParam,
+        "extra-param-key"
+      );
+      var valueInput = testUtils.findRenderedDOMComponentWithClass(
+        extraParam,
+        "extra-param-value"
+      );
+
+      var unique_key = _.uniqueId();
+      testUtils.Simulate.change(keyInput, {
+        target: { value: unique_key }
+      });
+      assert.include(
+        root.state.extra_params,
+        { key: unique_key, value: "" }
+      );
+      sinon.assert.calledWith(
+        syncExtraParametersStub,
+        root.state.extra_params);
+
+      var unique_value = _.uniqueId();
+      testUtils.Simulate.change(valueInput, {
+        target: { value: unique_value }
+      });
+      assert.include(
+        root.state.extra_params,
+        { key: unique_key, value: unique_value }
+      );
+      sinon.assert.calledWith(
+        syncExtraParametersStub,
+        root.state.extra_params);
+    });
+  });
+
+  it("should remove extra param after clicking link", () => {
+    // First add a few parameters so we can enter text in those fields.
+    testUtils.Simulate.click(addExtraParam);
+    testUtils.Simulate.click(addExtraParam);
+    testUtils.Simulate.click(addExtraParam);
+    var extraParams = testUtils.scryRenderedDOMComponentsWithClass(
+      root,
+      "extra-param"
+    );
+
+    // Now enter text in parameters to differentiate them.
+    extraParams.forEach(extraParam => {
+      var keyInput = testUtils.findRenderedDOMComponentWithClass(
+        extraParam,
+        "extra-param-key"
+      );
+      var valueInput = testUtils.findRenderedDOMComponentWithClass(
+        extraParam,
+        "extra-param-value"
+      );
+
+      testUtils.Simulate.change(keyInput, {
+        target: { value: _.uniqueId() }
+      });
+      testUtils.Simulate.change(valueInput, {
+        target: { value: _.uniqueId() }
+      });
+    });
+
+    // Now, we can remove each of the fields and verify.
+    var extra_params_copy = _.cloneDeep(root.state.extra_params);
+    while (root.state.extra_params.length > 0) {
+      var deleteLink = testUtils.findRenderedDOMComponentWithClass(
+        extraParams[0],
+        "delete-extra-param"
+      );
+      testUtils.Simulate.click(deleteLink);
+
+      extra_params_copy.shift();
+      assert.deepEqual(root.state.extra_params, extra_params_copy);
+      sinon.assert.calledWith(
+        syncExtraParametersStub,
+        root.state.extra_params
+      );
+    }
+  });
+});

--- a/test/components/parameter_entry_spec.ts
+++ b/test/components/parameter_entry_spec.ts
@@ -61,13 +61,6 @@ describe("ParameterEntryComponent", () => {
     });
   });
 
-  it("should contain an input for extra params", () => {
-    var extra_param_input = _.find(
-      inputs, input => _.contains(input.props.className, "extra-param"));
-
-    assert.equal(extra_param_input.props.children, "Extra parameters");
-  });
-
   it("should trigger onChange parameter when text is entered", () => {
     inputs.forEach(input => {
       testUtils.Simulate.change(input, {


### PR DESCRIPTION
Instead of one input field for the user to input JSON for extra parameters,
use individual input fields for each parameter. This includes a link to add
a new parameter, and links to remove old parameters.