### PR TITLE
Paginate by default, if possible

### DIFF
--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -96,7 +96,7 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
   }
 
   _canPaginate = (): boolean => {
-    // TODO: Can't paginate on users over personal projects domain.
+    // TODO: Also can't paginate on users over personal projects domain.
 
     return this.state.action.collection &&
       !this.state.action.collection_cannot_paginate;
@@ -147,7 +147,6 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
     }
     params = _.extend(params, this.state.params.optional_params);
 
-    // TODO: update tests for paginate_params.
     if (this._canPaginate()) {
       params = _.extend(params, this.state.params.paginate_params);
     }

--- a/src/components/paginate_entry.ts
+++ b/src/components/paginate_entry.ts
@@ -2,8 +2,6 @@ import React = require("react");
 
 var r = React.DOM;
 
-// TODO: Add tests.
-
 /**
  * Allows users to change their pagination settings.
  */
@@ -15,9 +13,7 @@ class PaginateEntry extends React.Component<PaginateEntry.Props, {}> {
     var limit_value = !this.props.paginate_params.limit ?
       "" : this.props.paginate_params.limit.toString();
     var offset_value = !this.props.paginate_params.offset ?
-      "" : this.props.paginate_params.offset.toString();
-
-    console.log(this.props.paginate_params);
+      "" : this.props.paginate_params.offset;
 
     return r.span({},
       r.input({

--- a/src/components/paginate_entry.ts
+++ b/src/components/paginate_entry.ts
@@ -1,0 +1,67 @@
+import React = require("react");
+
+var r = React.DOM;
+
+// TODO: Add tests.
+
+/**
+ * Allows users to change their pagination settings.
+ */
+class PaginateEntry extends React.Component<PaginateEntry.Props, {}> {
+  static create = React.createFactory(PaginateEntry);
+
+  private _renderPaginateInputs = () => {
+    // If the values are not set, or 0, display empty string.
+    var limit_value = !this.props.paginate_params.limit ?
+      "" : this.props.paginate_params.limit.toString();
+    var offset_value = !this.props.paginate_params.offset ?
+      "" : this.props.paginate_params.offset.toString();
+
+    console.log(this.props.paginate_params);
+
+    return r.span({},
+      r.input({
+        type: "number",
+        className: "paginate-entry-limit",
+        min: "0",
+        onChange: this.props.onPaginateChange("limit"),
+        placeholder: "Limit",
+        value: limit_value
+      }, "Limit"),
+      r.input({
+        type: "text",
+        className: "paginate-entry-offset",
+        onChange: this.props.onPaginateChange("offset"),
+        placeholder: "Offset",
+        value: offset_value
+      }, "Offset")
+    );
+  };
+
+  render() {
+    return r.div({
+        className: "paginate-entry",
+        children: [
+          this.props.text,
+          this.props.can_paginate ?
+            this._renderPaginateInputs() :
+            "Pagination is not available on this route."
+        ]
+      }
+    );
+  }
+}
+
+module PaginateEntry {
+  export interface Props {
+    can_paginate: boolean;
+    onPaginateChange: (limit_or_offset: string) =>
+      (event?: React.FormEvent) => void;
+    paginate_params: {
+      limit?: number;
+      offset?: string;
+    };
+    text: string;
+  }
+}
+export = PaginateEntry;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,19 +2,22 @@ interface BaseConstants {
   LOCALSTORAGE_KEY: string;
   CLIENT_ID: string;
   REDIRECT_URI: string;
+  INITIAL_PAGINATION_LIMIT: number;
 }
 
 var ghPagesConstants: BaseConstants = {
   LOCALSTORAGE_KEY: "api_tester_credentials",
   CLIENT_ID: "29147353239426",
   REDIRECT_URI:
-    "https://asana.github.io/node-asana-tester/popup_receiver.html"
+    "https://asana.github.io/node-asana-tester/popup_receiver.html",
+  INITIAL_PAGINATION_LIMIT: 10
 };
 
 var localhostConstants: BaseConstants = {
   LOCALSTORAGE_KEY: "api_tester_credentials",
   CLIENT_ID: "23824292948206",
-  REDIRECT_URI: "http://localhost:8338/popup_receiver.html"
+  REDIRECT_URI: "http://localhost:8338/popup_receiver.html",
+  INITIAL_PAGINATION_LIMIT: 10
 };
 
 var constants = process.env.USE_GH_PAGES ?

--- a/src/resources/interfaces.ts
+++ b/src/resources/interfaces.ts
@@ -4,6 +4,8 @@ interface Action {
   path: string;
   comment: string;
   params?: Parameter[];
+  collection?: boolean;
+  collection_cannot_paginate?: boolean;
 }
 
 interface Parameter {

--- a/test/components/explorer_spec.ts
+++ b/test/components/explorer_spec.ts
@@ -761,6 +761,86 @@ describe("ExplorerComponent", () => {
           assert.deepEqual(root.state.params, old_params);
         });
       });
+
+      describe("on pagination parameter input", () => {
+        var inputLimitParam: React.HTMLComponent;
+        var inputOffsetParam: React.HTMLComponent;
+
+        beforeEach(() => {
+          // Use a route that has pagination enabled.
+          testUtils.Simulate.change(selectResource, {
+            target: {value: "Users"}
+          });
+          testUtils.Simulate.change(selectRoute, {
+            target: {value: "findAll"}
+          });
+
+          inputLimitParam = testUtils.findRenderedDOMComponentWithClass(
+            root, "paginate-entry-limit");
+          inputOffsetParam = testUtils.findRenderedDOMComponentWithClass(
+            root, "paginate-entry-offset");
+        });
+
+        function _setDataForPaginationParam(
+          param: React.HTMLComponent, value: string, opt_validity?: boolean) {
+          testUtils.Simulate.change(param, {
+            target: {
+              value: value,
+              checkValidity: () =>
+              opt_validity !== undefined ? opt_validity : true
+            }
+          });
+        }
+
+        it("should change state after updating limit/offset values", () => {
+          _setDataForPaginationParam(inputOffsetParam, "abc abc");
+          assert.deepEqual(
+            root.state.params.paginate_params,
+            { limit: constants.INITIAL_PAGINATION_LIMIT, offset: "abc abc" }
+          );
+
+          _setDataForPaginationParam(inputLimitParam, "123");
+          assert.deepEqual(
+            root.state.params.paginate_params,
+            { limit: "123", offset: "abc abc" }
+          );
+        });
+
+        it("should remove parameter when clearing limit/offset input", () => {
+          _setDataForPaginationParam(inputLimitParam, "");
+          assert.deepEqual(root.state.params.paginate_params, {});
+
+          _setDataForPaginationParam(inputOffsetParam, "hi there");
+          assert.deepEqual(
+            root.state.params.paginate_params, { offset: "hi there" });
+
+          _setDataForPaginationParam(inputLimitParam, "123");
+          assert.deepEqual(
+            root.state.params.paginate_params,
+            { limit: "123", offset: "hi there" }
+          );
+
+          _setDataForPaginationParam(inputOffsetParam, "");
+          assert.deepEqual(
+            root.state.params.paginate_params, { limit: "123" });
+
+          _setDataForPaginationParam(inputLimitParam, "");
+          assert.deepEqual(root.state.params.paginate_params, {});
+        });
+
+        it("should not change state if validity check fails", () => {
+          var old_paginate_params = _.cloneDeep(
+            root.state.params.paginate_params);
+
+          _setDataForPaginationParam(inputLimitParam, "hi there", false);
+          assert.deepEqual(
+            root.state.params.paginate_params, old_paginate_params);
+
+          _setDataForPaginationParam(inputOffsetParam, "hi there", false);
+          assert.deepEqual(
+            root.state.params.paginate_params, old_paginate_params);
+        });
+      });
     });
 
     describe("on submit", () => {
@@ -808,7 +888,8 @@ describe("ExplorerComponent", () => {
           include_fields: ["other", "this"],
           required_params: _.object([required_param.name], ["123"]),
           optional_params: {abc: 456},
-          extra_params: {test: "hi"}
+          extra_params: {test: "hi"},
+          paginate_params: {}
         };
 
         testUtils.Simulate.submit(React.findDOMNode(routeEntry));
@@ -870,7 +951,8 @@ describe("ExplorerComponent", () => {
           include_fields: ["other", "this"],
           required_params: _.object([required_param.name], ["123"]),
           optional_params: {abc: 456},
-          extra_params: {test: "hi"}
+          extra_params: {test: "hi"},
+          paginate_params: {}
         };
 
         testUtils.Simulate.submit(React.findDOMNode(routeEntry));

--- a/test/components/paginate_entry_spec.ts
+++ b/test/components/paginate_entry_spec.ts
@@ -1,0 +1,105 @@
+import chai = require("chai");
+import React = require("react/addons");
+import sinon = require("sinon");
+import _ = require("lodash");
+
+import PaginateEntry = require("../../src/components/paginate_entry");
+
+var assert = chai.assert;
+var testUtils = React.addons.TestUtils;
+
+describe("PaginateEntryComponent", () => {
+  var sand: SinonSandbox;
+
+  var onPaginateChangeStub: SinonStub;
+
+  var root: PaginateEntry;
+  var limitInput: React.HTMLComponent;
+  var offsetInput: React.HTMLComponent;
+
+  beforeEach(() => {
+    sand = sinon.sandbox.create();
+
+    onPaginateChangeStub = sand.stub().returns(_.noop);
+  });
+
+  afterEach(() => {
+    sand.restore();
+  });
+
+  describe("when can paginate", () => {
+    beforeEach(() => {
+      root = testUtils.renderIntoDocument<PaginateEntry>(
+        PaginateEntry.create({
+          can_paginate: true,
+          onPaginateChange: onPaginateChangeStub,
+          paginate_params: {
+            limit: 5,
+            offset: "initial value"
+          },
+          text: "this is a test"
+        })
+      );
+      limitInput = testUtils.findRenderedDOMComponentWithClass(
+        root,
+        "paginate-entry-limit"
+      );
+      offsetInput = testUtils.findRenderedDOMComponentWithClass(
+        root,
+        "paginate-entry-offset"
+      );
+    });
+
+    it("should set initial values of input fields from state", () => {
+      assert.equal(limitInput.props.value, 5);
+      assert.equal(offsetInput.props.value, "initial value");
+    });
+
+    it("should trigger onChange property for limit/offset fields", () => {
+      testUtils.Simulate.change(limitInput, {
+        target: {
+          value: "1234"
+        }
+      });
+      sinon.assert.calledWith(onPaginateChangeStub, "limit");
+      assert(true);
+
+      testUtils.Simulate.change(offsetInput, {
+        target: {
+          value: "abc123"
+        }
+      });
+      sinon.assert.calledWith(onPaginateChangeStub, "offset");
+    });
+  });
+
+  describe("when cannot paginate", () => {
+    beforeEach(() => {
+      root = testUtils.renderIntoDocument<PaginateEntry>(
+        PaginateEntry.create({
+          can_paginate: false,
+          onPaginateChange: onPaginateChangeStub,
+          paginate_params: {
+            limit: 5,
+            offset: "initial value"
+          },
+          text: "this is a test"
+        })
+      );
+    });
+
+    it("should hide pagination input fields", () => {
+      var limitInputs = testUtils.scryRenderedDOMComponentsWithClass(
+        root,
+        "paginate-entry-limit"
+      );
+      assert.lengthOf(limitInputs, 0);
+
+      var offsetInputs = testUtils.scryRenderedDOMComponentsWithClass(
+        root,
+        "paginate-entry-offset"
+      );
+      assert.lengthOf(offsetInputs, 0);
+    });
+  });
+});


### PR DESCRIPTION
If the route allows pagination, then paginate by default. Provides the user with fields to specify limit and offset.